### PR TITLE
同パッケージ内でprivateな構造体を不変にできるかを試す

### DIFF
--- a/internal/app/adaptor/controller/task/tasks_controller.go
+++ b/internal/app/adaptor/controller/task/tasks_controller.go
@@ -29,7 +29,7 @@ func (c *TasksController) GetTasks(w http.ResponseWriter, r *http.Request) {
 		response[i] = &Response{
 			TaskId: t.TaskId(),
 			Name:   t.Name(),
-			Reward: uint64(t.Reward()),
+			Reward: t.Reward().Value(),
 		}
 	}
 

--- a/internal/app/domain/task/reward.go
+++ b/internal/app/domain/task/reward.go
@@ -2,7 +2,11 @@ package task
 
 import "errors"
 
-type Reward struct {
+type Reward interface {
+	Value() uint64
+}
+
+type rewardImpl struct {
 	value uint64
 }
 
@@ -10,11 +14,11 @@ const DefaultReward = 100
 
 func NewReward(value uint64) (Reward, error) {
 	if value < DefaultReward {
-		return Reward{}, errors.New("100より小さい報酬は設定できません")
+		return nil, errors.New("100より小さい報酬は設定できません")
 	}
-	return Reward{value: value}, nil
+	return rewardImpl{value: value}, nil
 }
 
-func (r Reward) Value() uint64 {
+func (r rewardImpl) Value() uint64 {
 	return r.value
 }

--- a/internal/app/domain/task/reward.go
+++ b/internal/app/domain/task/reward.go
@@ -2,15 +2,11 @@ package task
 
 import "errors"
 
-//type Reward interface {
-//	Value() uint64
-//}
-//
-//type rewardImpl struct {
-//	value uint64
-//}
+type Reward interface {
+	Value() uint64
+}
 
-type Reward struct {
+type reward struct {
 	value uint64
 }
 
@@ -18,15 +14,11 @@ const DefaultReward = 100
 
 func NewReward(value uint64) (Reward, error) {
 	if value < DefaultReward {
-		return Reward{}, errors.New("100より小さい報酬は設定できません")
+		return nil, errors.New("100より小さい報酬は設定できません")
 	}
-	return Reward{value: value}, nil
+	return reward{value: value}, nil
 }
 
-//func (r rewardImpl) Value() uint64 {
-//	return r.value
-//}
-
-func (r Reward) Value() uint64 {
+func (r reward) Value() uint64 {
 	return r.value
 }

--- a/internal/app/domain/task/reward.go
+++ b/internal/app/domain/task/reward.go
@@ -2,11 +2,15 @@ package task
 
 import "errors"
 
-type Reward interface {
-	Value() uint64
-}
+//type Reward interface {
+//	Value() uint64
+//}
+//
+//type rewardImpl struct {
+//	value uint64
+//}
 
-type rewardImpl struct {
+type Reward struct {
 	value uint64
 }
 
@@ -14,11 +18,15 @@ const DefaultReward = 100
 
 func NewReward(value uint64) (Reward, error) {
 	if value < DefaultReward {
-		return nil, errors.New("100より小さい報酬は設定できません")
+		return Reward{}, errors.New("100より小さい報酬は設定できません")
 	}
-	return rewardImpl{value: value}, nil
+	return Reward{value: value}, nil
 }
 
-func (r rewardImpl) Value() uint64 {
+//func (r rewardImpl) Value() uint64 {
+//	return r.value
+//}
+
+func (r Reward) Value() uint64 {
 	return r.value
 }

--- a/internal/app/domain/task/reward.go
+++ b/internal/app/domain/task/reward.go
@@ -2,13 +2,19 @@ package task
 
 import "errors"
 
-type Reward uint64
+type Reward struct {
+	value uint64
+}
 
 const DefaultReward = 100
 
 func NewReward(value uint64) (Reward, error) {
 	if value < DefaultReward {
-		return 0, errors.New("100より小さい報酬は設定できません")
+		return Reward{}, errors.New("100より小さい報酬は設定できません")
 	}
-	return Reward(value), nil
+	return Reward{value: value}, nil
+}
+
+func (r Reward) Value() uint64 {
+	return r.value
 }

--- a/internal/app/domain/task/task.go
+++ b/internal/app/domain/task/task.go
@@ -17,7 +17,8 @@ func NewTask(taskId uint64, name string, reward Reward) (*Task, error) {
 	}
 
 	// テスト 同パッケージ内でprivateな構造体を呼び出してみる
-	reward = Reward(1000)
+	// TODO 以下を呼べなくする
+	reward = Reward{value: 100}
 	fmt.Println(reward)
 
 	return &Task{

--- a/internal/app/domain/task/task.go
+++ b/internal/app/domain/task/task.go
@@ -15,16 +15,6 @@ func NewTask(taskId uint64, name string, reward Reward) (*Task, error) {
 		return &Task{}, errors.New("タスク名が不正です")
 	}
 
-	// テスト 同パッケージ内でprivateな構造体を呼び出してみる
-	// TODO 以下を呼べなくする
-	// reward = RewardImpl{value: 100} syntax error
-	//reward2 := Reward{} Invalid composite literal type: Reward
-	// しかし、rewardImplを直接呼び出せて、rewardとして返せてしまう
-	//a := rewardImpl{value: 100}
-	//fmt.Println(a)
-	// 値を直接書き換える
-	reward.value = 100
-
 	return &Task{
 		taskId: taskId,
 		name:   name,

--- a/internal/app/domain/task/task.go
+++ b/internal/app/domain/task/task.go
@@ -20,12 +20,14 @@ func NewTask(taskId uint64, name string, reward Reward) (*Task, error) {
 	// TODO 以下を呼べなくする
 	// reward = RewardImpl{value: 100} syntax error
 	//reward2 := Reward{} Invalid composite literal type: Reward
-	fmt.Println(reward)
+	// しかし、rewardImplを直接呼び出せて、rewardとして返せてしまう
+	a := rewardImpl{value: 100}
+	fmt.Println(a)
 
 	return &Task{
 		taskId: taskId,
 		name:   name,
-		reward: reward,
+		reward: a,
 	}, nil
 }
 

--- a/internal/app/domain/task/task.go
+++ b/internal/app/domain/task/task.go
@@ -2,7 +2,6 @@ package task
 
 import (
 	"errors"
-	"fmt"
 )
 
 type Task struct {
@@ -21,13 +20,15 @@ func NewTask(taskId uint64, name string, reward Reward) (*Task, error) {
 	// reward = RewardImpl{value: 100} syntax error
 	//reward2 := Reward{} Invalid composite literal type: Reward
 	// しかし、rewardImplを直接呼び出せて、rewardとして返せてしまう
-	a := rewardImpl{value: 100}
-	fmt.Println(a)
+	//a := rewardImpl{value: 100}
+	//fmt.Println(a)
+	// 値を直接書き換える
+	reward.value = 100
 
 	return &Task{
 		taskId: taskId,
 		name:   name,
-		reward: a,
+		reward: reward,
 	}, nil
 }
 

--- a/internal/app/domain/task/task.go
+++ b/internal/app/domain/task/task.go
@@ -2,6 +2,7 @@ package task
 
 import (
 	"errors"
+	"fmt"
 )
 
 type Task struct {
@@ -14,6 +15,10 @@ func NewTask(taskId uint64, name string, reward Reward) (*Task, error) {
 	if name == "" || len(name) > 50 {
 		return &Task{}, errors.New("タスク名が不正です")
 	}
+
+	// テスト 同パッケージ内でprivateな構造体を呼び出してみる
+	reward = Reward(1000)
+	fmt.Println(reward)
 
 	return &Task{
 		taskId: taskId,

--- a/internal/app/domain/task/task.go
+++ b/internal/app/domain/task/task.go
@@ -18,7 +18,8 @@ func NewTask(taskId uint64, name string, reward Reward) (*Task, error) {
 
 	// テスト 同パッケージ内でprivateな構造体を呼び出してみる
 	// TODO 以下を呼べなくする
-	reward = Reward{value: 100}
+	// reward = RewardImpl{value: 100} syntax error
+	//reward2 := Reward{} Invalid composite literal type: Reward
 	fmt.Println(reward)
 
 	return &Task{


### PR DESCRIPTION
## 背景
- Goでは同パッケージの構造体のprivateなフィールドの値を書き換えることができる。

## アプローチ方法
- ①同パッケージにならないようにディレクトリを用意する。
- ②IFを実装する。

今回は②を試す。

## 解決策
- interface（IF）を実装し、コンポジション先をIFにすることによって直接フィールドにアクセスできないようにする。
- コンストラクタではIFを実装するreward構造体を返却する。

## 参考
https://zenn.dev/link/comments/e55d0462117d2c