### PR TITLE
プリミティブ型に型を定義し、値オブジェクトして実装する。

### DIFF
--- a/internal/app/adaptor/controller/task/tasks_controller.go
+++ b/internal/app/adaptor/controller/task/tasks_controller.go
@@ -28,7 +28,7 @@ func (c *TasksController) GetTasks(w http.ResponseWriter, r *http.Request) {
 	for i, t := range tasks {
 		response[i] = &Response{
 			TaskId: t.TaskId(),
-			Name:   t.Name(),
+			Name:   t.Name().Value(),
 			Reward: t.Reward().Value(),
 		}
 	}

--- a/internal/app/domain/task/name.go
+++ b/internal/app/domain/task/name.go
@@ -1,0 +1,19 @@
+package task
+
+import "errors"
+
+type Name interface {
+	Value() string
+}
+type name string
+
+func NewName(value string) (Name, error) {
+	if value == "" || len(value) > 50 {
+		return nil, errors.New("タスク名が不正です")
+	}
+	return name(value), nil
+}
+
+func (n name) Value() string {
+	return string(n)
+}

--- a/internal/app/domain/task/task.go
+++ b/internal/app/domain/task/task.go
@@ -1,20 +1,12 @@
 package task
 
-import (
-	"errors"
-)
-
 type Task struct {
 	taskId uint64
-	name   string
+	name   Name
 	reward Reward
 }
 
-func NewTask(taskId uint64, name string, reward Reward) (*Task, error) {
-	if name == "" || len(name) > 50 {
-		return &Task{}, errors.New("タスク名が不正です")
-	}
-
+func NewTask(taskId uint64, name Name, reward Reward) (*Task, error) {
 	return &Task{
 		taskId: taskId,
 		name:   name,
@@ -26,7 +18,7 @@ func (t Task) TaskId() uint64 {
 	return t.taskId
 }
 
-func (t Task) Name() string {
+func (t Task) Name() Name {
 	return t.name
 }
 

--- a/internal/app/infrastructure/repository/task/tasks_repository.go
+++ b/internal/app/infrastructure/repository/task/tasks_repository.go
@@ -48,11 +48,15 @@ func (r *TasksRepository) GetAllTasks() ([]*taskDomain.Task, error) {
 }
 
 func (m DataModel) toTask() (*taskDomain.Task, error) {
+	name, err := taskDomain.NewName(m.Name)
+	if err != nil {
+		return nil, err
+	}
 	reward, err := taskDomain.NewReward(m.Reward)
 	if err != nil {
 		return nil, err
 	}
-	task, err := taskDomain.NewTask(m.TaskId, m.Name, reward)
+	task, err := taskDomain.NewTask(m.TaskId, name, reward)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## 概要
- Rewardと実装の仕方を変えてみた。
- structを定義し構造体を実装するreward.goとプリミティブ型に型定義するname.goの2パターンを実装し、比較する。

プリミティブ型に型定義する場合
- Getterにて独自型ではなく、プリミティブ型を返さないと、呼び出し元でキャストする必要があり冗長に感じる。
- ただし、上記実装をすると独自型を用意したのに、プリミティブ型を返却することに違和感を感じる。
- 結果、構造体を定義し、フィールドにプリミティブ型を持たせたほうが自然に感じる。